### PR TITLE
feat: Add Jina Reader integration for URL content fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ LLaMB is a command-line tool that allows you to interact with Large Language Mod
 - 💬 **Conversation history** - Follow-up on previous questions with context
 - 🔄 **Continuous conversation** - Interactive chat mode for follow-up questions
 - 📄 **File handling** - Include file contents in your questions and save responses to files
+- 🌐 **URL content** - Fetch URL content using Jina Reader to include in prompts
 - 🔤 **Smart file extensions** - Automatically uses appropriate file extensions for code outputs
 - 📝 **Prompt templates** - Save and reuse common prompts to streamline frequent tasks
 - 🔄 **Multiple providers** - Support for OpenAI, Anthropic, Mistral, Ollama, and more
@@ -43,6 +44,12 @@ Or add a provider using the interactive command:
 
 ```bash
 llamb provider:add
+```
+
+You can set your Jina Reader API key:
+
+```bash
+llamb jina:apikey
 ```
 
 LLaMB supports many providers out of the box with pre-configured settings:
@@ -91,13 +98,29 @@ man llamb
 llamb what is the best command to install docker on ubuntu
 ```
 
-### File Operations
+### File and URL Operations
 
 #### Include a file in your question
 
 ```bash
 llamb -f script.js "Explain this code and suggest improvements"
 llamb "Summarize this document" -f document.txt
+```
+
+#### Fetch URL content with Jina Reader
+
+```bash
+# Basic usage - fetch URL content and analyze it
+llamb -j https://example.com "Explain this website"
+
+# Combine with other options
+llamb -j https://github.com/owner/repo/blob/main/README.md -p openai "What features does this project have?"
+
+# Set or update the Jina Reader API key (optional)
+llamb jina:apikey
+
+# Test Jina Reader with a URL
+llamb jina:test https://example.com
 ```
 
 #### Save responses to files

--- a/man/man1/llamb.1
+++ b/man/man1/llamb.1
@@ -47,6 +47,9 @@ Do not use conversation history for this request
 .B \-f, \-\-file <path>
 Path to a file to include with your question
 .TP
+.B \-j, \-\-jina <url>
+URL to fetch content from using Jina Reader
+.TP
 .B \-o, \-\-output [path]
 Save the response to a file. If path is not provided, you will be prompted for a filename. When saving code responses, appropriate file extensions will be automatically applied if the response is a pure code block.
 .TP
@@ -119,6 +122,12 @@ Delete a prompt template
 .TP
 .B llamb prompt:show
 Show details of a specific prompt template
+.TP
+.B llamb jina:apikey
+Set or update the Jina Reader API key
+.TP
+.B llamb jina:test <url>
+Test the Jina Reader API with a URL
 .SH SLASH COMMANDS
 Llamb supports short-form slash commands when entering questions. In continuous conversation mode (-c), there are additional slash commands available:
 .TP
@@ -164,6 +173,15 @@ Include a file with your question:
 .TP
 Process file contents:
 .B llamb "Summarize this" -f document.txt
+.TP
+Fetch URL content using Jina Reader:
+.B llamb -j https://example.com "Explain this website"
+.TP
+Set or update the Jina Reader API key:
+.B llamb jina:apikey
+.TP
+Test Jina Reader with a URL:
+.B llamb jina:test https://example.com
 .TP
 Save response (prompts for filename):
 .B llamb "Generate JSON" -o

--- a/src/cli/jinaReaderCli.ts
+++ b/src/cli/jinaReaderCli.ts
@@ -1,0 +1,79 @@
+import chalk from 'chalk';
+import { Command } from 'commander';
+import inquirer from 'inquirer';
+import { fetchJinaReader, setJinaReaderApiKey, getJinaReaderApiKey } from '../services/jinaReader.js';
+
+/**
+ * Register Jina Reader related commands with the CLI
+ * @param program Commander program instance
+ */
+export function registerJinaReaderCommands(program: Command): void {
+  // jina:apikey command
+  program
+    .command('jina:apikey')
+    .alias('jina apikey')
+    .description('Set or update the Jina Reader API key')
+    .option('--key <key>', 'API key to set')
+    .action(async (options) => {
+      try {
+        // If key is provided directly, use it; otherwise prompt
+        if (options.key) {
+          // Non-interactive update
+          setJinaReaderApiKey(options.key);
+          console.log(chalk.green('✓ Jina Reader API key updated successfully'));
+        } else {
+          // Interactive update
+          const answers = await inquirer.prompt([
+            {
+              type: 'password',
+              name: 'apiKey',
+              message: 'Enter Jina Reader API key:',
+              validate: (input) => input.trim() !== '' ? true : 'API key cannot be empty'
+            }
+          ]);
+
+          setJinaReaderApiKey(answers.apiKey);
+          console.log(chalk.green('✓ Jina Reader API key updated successfully'));
+        }
+      } catch (error: any) {
+        console.error(chalk.red('Error updating Jina Reader API key:'), error.message);
+      }
+    });
+
+  // jina:test command
+  program
+    .command('jina:test')
+    .alias('jina test')
+    .description('Test the Jina Reader API with a URL')
+    .argument('<url>', 'URL to test with Jina Reader')
+    .action(async (url) => {
+      try {
+        console.log(chalk.dim(`Testing Jina Reader with URL: ${url}`));
+        
+        // Check if API key is configured
+        const apiKey = getJinaReaderApiKey();
+        if (!apiKey) {
+          console.log(chalk.yellow('No Jina Reader API key configured. Requests will be made without authentication.'));
+          console.log(chalk.cyan('To set an API key, run:'));
+          console.log(chalk.bold('  llamb jina:apikey'));
+        } else {
+          console.log(chalk.green('✓ Jina Reader API key is configured'));
+        }
+        
+        // Fetch content using Jina Reader
+        console.log(chalk.dim('Fetching content...'));
+        const content = await fetchJinaReader(url);
+        
+        // Display a preview of the content
+        console.log(chalk.green(`✓ Content fetched successfully (${(content.length / 1024).toFixed(1)} KB)`));
+        console.log(chalk.cyan('\nContent Preview:'));
+        console.log(chalk.dim('─'.repeat(50)));
+        console.log(content.slice(0, 500) + (content.length > 500 ? '...' : ''));
+        console.log(chalk.dim('─'.repeat(50)));
+        console.log(chalk.cyan(`\nTo use this content with llamb, run:`));
+        console.log(chalk.bold(`  llamb -j ${url} "Your question about the content"`));
+      } catch (error: any) {
+        console.error(chalk.red('Error testing Jina Reader:'), error.message);
+      }
+    });
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -18,6 +18,7 @@ export interface ConfigSchema {
   defaultProvider: string;
   useProgressOnly: boolean;
   useInkUI: boolean;
+  jinaReaderApiKey?: string;
 }
 
 const config = new Conf<ConfigSchema>({
@@ -38,6 +39,10 @@ const config = new Conf<ConfigSchema>({
     useInkUI: {
       type: 'boolean',
       default: true, // Use the ink UI by default
+    },
+    jinaReaderApiKey: {
+      type: 'string',
+      default: '', // No default Jina Reader API key
     }
   },
 });

--- a/src/services/jinaReader.ts
+++ b/src/services/jinaReader.ts
@@ -1,0 +1,61 @@
+import config from '../config/index.js';
+import chalk from 'chalk';
+
+/**
+ * Fetches content from a URL using Jina Reader
+ * @param url URL to fetch content from
+ * @returns Markdown content from the URL
+ */
+export async function fetchJinaReader(url: string): Promise<string> {
+  try {
+    // Get API key from config if available
+    const apiKey = config.get('jinaReaderApiKey');
+    
+    // Construct the Jina Reader URL
+    const jinaUrl = `https://r.jina.ai/${url}`;
+    
+    // Set up headers
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    
+    // Add authorization header if API key is available
+    if (apiKey) {
+      headers['Authorization'] = `Bearer ${apiKey}`;
+    }
+    
+    // Make the request to Jina Reader
+    const response = await fetch(jinaUrl, {
+      method: 'GET',
+      headers,
+    });
+    
+    if (!response.ok) {
+      throw new Error(`Failed to fetch content: ${response.status} ${response.statusText}`);
+    }
+    
+    // Get response text
+    const content = await response.text();
+    
+    return content;
+  } catch (error: any) {
+    console.error(chalk.red('Error fetching content from Jina Reader:'), error.message);
+    throw new Error(`Failed to fetch content from ${url}: ${error.message}`);
+  }
+}
+
+/**
+ * Set the Jina Reader API key
+ * @param apiKey The API key to set
+ */
+export function setJinaReaderApiKey(apiKey: string): void {
+  config.set('jinaReaderApiKey', apiKey);
+}
+
+/**
+ * Get the Jina Reader API key
+ * @returns The API key or an empty string if not set
+ */
+export function getJinaReaderApiKey(): string {
+  return config.get('jinaReaderApiKey') || '';
+}


### PR DESCRIPTION
- Introduced new commands to fetch content from URLs using Jina Reader.
- Updated README and man pages to document the new URL handling features.
- Added functionality to set and manage the Jina Reader API key.
- Enhanced CLI to support URL content fetching in prompts and responses.